### PR TITLE
add configuration to specify text to replace line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,21 @@
 let g:voiceroid_vrx_who = '琴葉 葵'
 ```
 
+### 改行の扱いを変更する
+
+複数行を喋らせる場合、デフォルトでは改行は維持されてVOICEROIDに渡されます。
+hard-wrapされたファイルを喋らせたい場合など、改行の扱いを変更したい場合は、
+`g:voiceroid_linebreak_replacer` で改行を置換する文字列を指定できます。
+
+設定例: 改行を単に無視し、1行に連結する
+
+```vim
+let g:voiceroid_linebreak_replacer = ''
+```
+
 ## Known Issues
 
-*   事前に 民安★TALK を起動しないと `:VoiceroidTalk` が終了しなくなる
-*   長い文章(8000バイトあるいは8000文字以上)をいっぺんに喋らせられない
+*   長い文章(およそ3.3万文字以上)をいっぺんに喋らせられない
 
 
 [voiceroid]:https://www.ah-soft.com/voiceroid/

--- a/autoload/voiceroid.vim
+++ b/autoload/voiceroid.vim
@@ -33,6 +33,6 @@ function! voiceroid#talk(text)
   " TODO: seprate text into chunks which length is under 8000
   let text = s:getVrxWho() . a:text
   let escaped_text = substitute(text, '"', '""', 'g')
-  call system(vrxpath . ' "' . escaped_text . '"')
+  call job_start(vrxpath . ' "' . escaped_text . '"')
   return v:shell_error
 endfunction

--- a/plugin/voiceroid.vim
+++ b/plugin/voiceroid.vim
@@ -9,7 +9,8 @@ function! s:talk(...) range abort
   else
     let lines = getline(a:firstline, a:lastline)
     let lines = map(lines, 'trim(v:val)')
-    let text = join(lines, '')
+    let text = join(lines, get(g:, 'voiceroid_linebreak_replacer', "\n"))
+    let text = trim(text)
   endif
 
   try


### PR DESCRIPTION
vrx.exeの起動にjobを使うようにしたところ、改行を維持して文章をVOICEROIDに渡せるようになりました。
また、こちらで検証したところ今までよりも長い文章を渡せるようになったようです。

以前の改行の取扱いを復元できるようにオプション`g:voiceroid_linebreak_replacer`も追加しました。

よろしくおねがいします。